### PR TITLE
Ignore .jekyll-cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ credentials.yaml
 .ssh/*
 **/export
 export
+.jekyll-cache


### PR DESCRIPTION
When building the site and demos locally I got a load of Jekyll cache files along with it. They seem like they should be ignored.