### PR TITLE
Fix follow snippet FlxCameraFollowStyle API link

### DIFF
--- a/_proofs/camera/follow.md
+++ b/_proofs/camera/follow.md
@@ -7,7 +7,7 @@ tags: [camera]
 ---
 You can set a {% api flixel.FlxCamera %} to follow a {% api flxel.FlxObject %}. This will allow your camera to scroll as the object moves.
 
-There are 6 built-in styles for {% api flixel.FlxCamera.FlxCameraFollowStyle %}, although you are free to set your own {% api flixel.FlxCamera.deadzone %}, if you wish.
+There are 6 built-in styles for {% api flixel.FlxCameraFollowStyle %}, although you are free to set your own {% api flixel.FlxCamera.deadzone %}, if you wish.
 
 ```haxe
 // tell the camera to follow sprite with the LOCKON style


### PR DESCRIPTION
It now goes to https://api.haxeflixel.com/flixel/FlxCameraFollowStyle.html instead of the 404 link