### PR TITLE
Responsive sidebar

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,15 +5,15 @@
 
   <title>HaxeFlixel Snippets{% if page.title %}{% if page.title != "Index" %} - {{ page.title }}{% endif %}{% endif %}</title>
   <meta name="description" content="HaxeFlixel Snippets">
-  <link rel="shortcut icon" href="{{ site.url }}/assets/images/favicon.ico">
+  <link rel="shortcut icon" href="{{ '/assets/images/favicon.ico' | relative_url }}">
 
   <link href='https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700,300italic,400italic,500italic,700italic' rel='stylesheet' type='text/css'>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fork-awesome@1.2.0/css/fork-awesome.min.css" integrity="sha256-XoaMnoYC5TH6/+ihMEnospgm0J1PM/nioxbOUdnM8HY=" crossorigin="anonymous">
 
-  <link rel="stylesheet" href="/assets/css/bootstrap-social.css">
-  <link rel="stylesheet" href="/assets/css/main.css">
-  <link rel="stylesheet" href="/assets/css/highlight.css">
+  <link rel="stylesheet" href="{{ '/assets/css/bootstrap-social.css' | relative_url }}">
+  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+  <link rel="stylesheet" href="{{ '/assets/css/highlight.css' | relative_url }}">
   
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,13 +1,17 @@
     <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg navbar-inverse fixed-top" style="margin-bottom: 0">
+    <nav class="top-navbar navbar navbar-expand-lg navbar-inverse fixed-top" style="margin-bottom: 0">
       <div class="container">
-        <a class="navbar-brand" href="/"><span><img id="brand-logo" src="/assets/images/hfm-logo.svg" alt="HaxeFlixel Logo"/> HaxeFlixel Snippets</span></a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <a class="navbar-brand" href="{{ '/' | relative_url }}">
+          <span><img id="brand-logo" src="{{ '/assets/images/hfm-logo.svg' | relative_url }}" alt="HaxeFlixel Logo"/> HaxeFlixel Snippets</span>
+        </a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#site-navbar" aria-controls="site-navbar" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <div class="collapse navbar-collapse" id="site-navbar">
           <ul class="navbar-nav navbar-top-links me-auto mb-2 mb-lg-0">
-            <li class="nav-link{% if page.title == "About" %} active" aria-current="page{% endif %}"><a href="/about" >About</a></li>
+            <li class="nav-link{% if page.title == 'About' %} active" aria-current="page{% endif %}">
+              <a href="{{'/about' | relative_url }}" >About</a>
+            </li>
             <li class="nav-link">
               <a href="https://haxeflixel.com" title="" data-original-title="">
                 <i class="fa fa-fw fa-share"></i>
@@ -17,7 +21,7 @@
           </ul>
           <form class="d-flex navbar-form search-form" role="search" action="https://google.com/search" method="get">
               <input type="search" name="q" class="form-control me-2" placeholder="Search" aria-label="Search">
-              <input type="hidden" name="q" value="site:https://snippets.haxeflixel.com/">
+              <input type="hidden" name="q" value="site:{{ site.url | relative_url }}">
           </form>
         </div>
       </div>

--- a/_includes/sidebarnav.html
+++ b/_includes/sidebarnav.html
@@ -1,8 +1,8 @@
-    <aside class="sidebar-nav p-3 me-4 ">
-        <ul class="list-unstyled ps-0" role="navigation">
+    <nav class="sidebar-nav me-lg-4 p-3 navbar navbar-expand flex-column justify-content-start align-items-stretch h-100 w-100 w-lg-25">
+        <ul class="list-unstyled navbar-nav ps-0 flex-column justify-content-start w-100" role="navigation">
             {% assign concepts = site.concepts | sort: 'order' %}
             {% for concept in concepts %}
-            <li id="li-{{ concept.title | slugify }}" class="mb-1">
+            <li id="li-{{ concept.title | slugify }}" class="mb-1 nav-item">
                 <button class="btn btn-toggle align-items-center rounded" data-bs-toggle="collapse" data-bs-target="#{{ concept.title | slugify }}-collapse" {% if page.title == concept.title or page.concept == concept.title %}aria-expanded="true"{% endif %}>
                     {{ concept.title }}
                 </button>
@@ -11,7 +11,7 @@
                         {% assign proofs = site.proofs | where:"concept",concept.title | sort: 'order' %}
                         {% for proof in proofs %}
                             <li id="li-{{proof.concept | slugify }}-{{ proof.title | slugify }}">
-                                <a href="/{{ proof.concept | slugify }}/{{ proof.title | slugify }}" class="link-dark rounded {% if page.title == proof.title %} active{% endif %}">{{ proof.title }}</a>
+                                <a href="{{ proof.concept | prepend: '/' | slugify | relative_url }}/{{ proof.title | slugify }}" class="link-dark rounded {% if page.title == proof.title %} active{% endif %}">{{ proof.title }}</a>
                             </li>
                         {% endfor %}
                     </ul>
@@ -19,5 +19,4 @@
             </li>
             {% endfor %}
         </ul>
-    </aside>
-
+    </nav>

--- a/_includes/sidebarnav.html
+++ b/_includes/sidebarnav.html
@@ -1,4 +1,4 @@
-    <nav class="sidebar-nav me-lg-4 p-3 navbar navbar-expand flex-column justify-content-start align-items-stretch h-100 w-100 w-lg-25">
+    <nav class="sidebar-nav me-lg-4 mb-5 mb-lg-0 p-3 navbar navbar-expand flex-column justify-content-start align-items-stretch h-100 w-100 w-lg-25">
         <ul class="list-unstyled navbar-nav ps-0 flex-column justify-content-start w-100" role="navigation">
             {% assign concepts = site.concepts | sort: 'order' %}
             {% for concept in concepts %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,11 +5,11 @@
 
     {% include navbar.html %}
 
-    <div class="container navbar-offset d-flex container-main">
+    <div class="container-main container-lg d-flex flex-wrap">
 
         {% include sidebarnav.html %}
 
-        <main >
+        <main class="prevent-wrap-flex-item w-100">
           {% if page.title %}
           {% if page.title <> 'Index' %}
           <div class="page-header">

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -30,7 +30,7 @@ body {
   margin-bottom:7px;
 }
 
-.navbar {
+.top-navbar {
   min-height: 50px;
   margin-bottom:22px;
   border: 1px solid transparent;
@@ -170,7 +170,7 @@ canvas.demo-back {
   border: 2px solid #e3e3e3;
   border-radius: 4px;
   box-shadow: inset 0 1px 1px rgba(0,0,0,.05);
-  width:25%;
+  width: 25%;
 }
 
 .sidebar-nav .btn-toggle {
@@ -219,7 +219,7 @@ canvas.demo-back {
   background-color: transparent;
   font-weight: 400;
   border: 0;
-  width:100%;
+  width: calc(100% - 1.25rem);
 }
 
 .sidebar-nav .btn-toggle-nav a::before {
@@ -250,9 +250,6 @@ canvas.demo-back {
   box-shadow: none;
 }
 
-main {
-  width: 75%;
-}
 
 .jumbotron {
   border-radius: 6px;
@@ -329,4 +326,26 @@ figure {
     margin: auto;
     background: lightgray;
     margin-bottom: 1rem;
+}
+
+@media (max-width: 991px) {
+  .sidebar-nav .navbar-nav {
+    column-count: 2;
+    display: block;
+  }
+}
+
+.sidebar-nav .nav-item {
+  break-inside: avoid;
+}
+
+/* prevent flex item to wrap/overflow, instead it
+fills all remaining space */
+.prevent-wrap-flex-item {
+  min-width: 1px;
+  flex: 1;
+}
+
+@media (min-width: 992px) {
+  .w-lg-25 { width: 25% !important; }
 }


### PR DESCRIPTION
As part of #26 .

- move sidebar to the top on screens below `-lg` breakpoint (similar to flixel site)
- use jekyll `relative_url` filter in some places 
  (it was necessary to make site work with my github deployment, should not affect the normal one)

You can preview changes [there](https://t1ml3arn.github.io/snippets.haxeflixel.com/basics/adding/). Use `ctrl+shift+m` (or just resize browser's window) to see it. Note that some links may not work there, but links to proofs are fine.

![image](https://github.com/HaxeFlixel/snippets.haxeflixel.com/assets/9349164/2faf39f1-1d00-4393-8be6-351bcbcd3eec)
