### PR TITLE
Bounce the ball on screen instead of Offscreen at the bottom and right

### DIFF
--- a/demos/states/flxsubstate/source/PlayState.hx
+++ b/demos/states/flxsubstate/source/PlayState.hx
@@ -46,11 +46,11 @@ class PlayState extends FlxState
 	{
 		super.update(elapsed);
 		
-		if (sprite.x < 0 || sprite.x > FlxG.width)
+		if (sprite.x < 0 || sprite.x > FlxG.width - sprite.width)
 		{
 			sprite.velocity.x *= -1;
 		}
-		if (sprite.y < 0 || sprite.y > FlxG.height)
+		if (sprite.y < 0 || sprite.y > FlxG.height - sprite.height)
 		{
 			sprite.velocity.y *= -1;
 		}

--- a/demos/states/flxsubstate/source/PlayState.hx
+++ b/demos/states/flxsubstate/source/PlayState.hx
@@ -46,11 +46,11 @@ class PlayState extends FlxState
 	{
 		super.update(elapsed);
 		
-		if (sprite.x < 0 || sprite.x > FlxG.width - sprite.width)
+		if (sprite.x < 0 || sprite.x + sprite.width > FlxG.width)
 		{
 			sprite.velocity.x *= -1;
 		}
-		if (sprite.y < 0 || sprite.y > FlxG.height - sprite.height)
+		if (sprite.y < 0 || sprite.y + sprite.height > FlxG.height)
 		{
 			sprite.velocity.y *= -1;
 		}


### PR DESCRIPTION
Despite being a neat small visual thing, why not have the ball bounce off inside the window instead bouncing it off screen on the right of the window and at the bottom